### PR TITLE
chore: extract dss monitoring telegraf configuration from the common configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+# [v1.5.0] - 2025-07-28
+
+### Added
+
+- Added support for `govern` nodes
+
+### Changed
+### Fixed
+
+- Fixed the dss runtime DB process pattern in telegraf procstat probe
+
 # [v1.4.0] - 2025-07-21
 
 ### Added

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: dataiku
 name: dss
-version: 1.4.0
+version: 1.5.0
 readme: README.md
 authors:
 - Jean-Bernard Jansen

--- a/roles/install_telegraf/defaults/main.yml
+++ b/roles/install_telegraf/defaults/main.yml
@@ -30,6 +30,31 @@ telegraf_conf_core_content: |
   {% else %}
     omit_hostname = true
   {% endif %}
+telegraf_conf_dss_monitoring_content: |
+  {% if telegraf_conf_use_legacy_graphite | bool is true %}
+    [[inputs.socket_listener]]
+      service_address = "tcp://127.0.0.1:9109"
+      data_format = "graphite"
+      templates = [
+        "dss.*.server.jvm.threads.*.count                     measurement.dss_id.measurement.measurement.measurement.dimension.field",
+        "dss.*.server.jvm.memory.pools.*.*                    measurement.dss_id.measurement.measurement.measurement.field.pool.dimension",
+        "dss.*.server.jvm.memory.*.*                          measurement.dss_id.measurement.measurement.field.memory.dimension",
+        "dss.*.server.jvm.memory.total.*                      measurement.dss_id.measurement.measurement.measurement.field.dimension",
+        "dss.*.server.dku.jobs.activities.*                   measurement.dss_id.measurement.measurement.measurement.field.activity_state dimension=count",
+        "dss.*.server.dku.jobs.*.*                            measurement.dss_id.measurement.measurement.field.job_state.dimension",
+        "dss.*.server.dku.objectsCounts.global.*              measurement.dss_id.measurement.measurement.measurement.field.kind dimension=count",
+        "dss.*.server.dku.ml.predictionTrain.*.*              measurement.dss_id.measurement.measurement.measurement.field.kind.dimension",
+        "dss.*.server.dku.notifications.queue.*.size.*        measurement.dss_id.measurement.measurement.measurement.measurement.queue.size.dimension",
+        "dss.*.server.dku.notifications.publish.*.*           measurement.dss_id.measurement.measurement.measurement.field.notification.dimension",
+        "dss.*.server.dku.notifications.publish.*             measurement.dss_id.measurement.measurement.measurement.field.dimension notification=all",
+      ]
+    {% else %}
+    [[inputs.prometheus]]
+      urls = ["http://localhost:10000/public/api/metrics-prometheus"]
+      username = "${DSS_API_KEY}"
+      tagexclude = ["url"]
+      namepass = ["jvm_threads_*","jvm_memory_*","dku_jobs_activities_*","dku_jobs_*","dku_objectsCounts_global_*","dku_ml_predictionTrain_*","dku_notifications_queue_*","dku_notifications_publish_*"]
+    {% endif %}
 telegraf_conf_inputs_content: |
   [[inputs.cpu]]
     percpu = true
@@ -62,14 +87,14 @@ telegraf_conf_inputs_content: |
   [[inputs.procstat]]
     interval = "30s"
     pattern = "dataiku-fm-agent"
-    tag_with = ["pid"]
+    tag_with = ["pid", "cmdline"]
     [inputs.procstat.tags]
       dss_id = "{{ telegraf_conf_dss_id }}"
       dimension = "dataiku-fm-agent"
   [[inputs.procstat]]
     interval = "30s"
     pattern = "/usr/sbin/nginx.*-c {{ telegraf_conf_dss_datadir }}"
-    tag_with = ["pid"]
+    tag_with = ["pid", "cmdline"]
     [inputs.procstat.tags]
       dss_id = "{{ telegraf_conf_dss_id }}"
       dimension = "dss-nginx"
@@ -80,7 +105,7 @@ telegraf_conf_inputs_content: |
   {% else %}
     pattern = "(/usr/pgsql-17/bin/postgres|/usr/pgsql-10/bin/postmaster) -D /data/pgsql/data"
   {% endif %}
-    tag_with = ["pid"]
+    tag_with = ["pid", "cmdline"]
     [inputs.procstat.tags]
       dss_id = "{{ telegraf_conf_dss_id }}"
       dimension = "dss-runtimedb"
@@ -88,7 +113,7 @@ telegraf_conf_inputs_content: |
   [[inputs.procstat]]
     interval = "30s"
     pattern = "docker-compose.*--file {{ telegraf_conf_dss_installdir }}/story/docker-compose\\.yml"
-    tag_with = ["pid"]
+    tag_with = ["pid", "cmdline"]
     [inputs.procstat.tags]
       dss_id = "{{ telegraf_conf_dss_id }}"
       dimension = "dss-story"
@@ -100,7 +125,7 @@ telegraf_conf_inputs_content: |
   {% else %}
     pattern = "Ddku\\.backend.*-cp {{ telegraf_conf_dss_datadir }}"
   {% endif %}
-    tag_with = ["pid"]
+    tag_with = ["pid", "cmdline"]
     [inputs.procstat.tags]
       dss_id = "{{ telegraf_conf_dss_id }}"
       dimension = "dss-backend"
@@ -108,40 +133,19 @@ telegraf_conf_inputs_content: |
   [[inputs.procstat]]
     interval = "30s"
     pattern = "Ddku\\.fek.*-cp {{ telegraf_conf_dss_datadir }}"
-    tag_with = ["pid"]
+    tag_with = ["pid", "cmdline"]
     [inputs.procstat.tags]
       dss_id = "{{ telegraf_conf_dss_id }}"
       dimension = "dss-fek"
   [[inputs.procstat]]
     interval = "30s"
     pattern = "Ddku\\.jek.*-cp {{ telegraf_conf_dss_datadir }}"
-    tag_with = ["pid"]
+    tag_with = ["pid", "cmdline"]
     [inputs.procstat.tags]
       dss_id = "{{ telegraf_conf_dss_id }}"
       dimension = "dss-jek"
-  {% if telegraf_conf_use_legacy_graphite | bool is true %}
-  [[inputs.socket_listener]]
-    service_address = "tcp://127.0.0.1:9109"
-    data_format = "graphite"
-    templates = [
-      "dss.*.server.jvm.threads.*.count                     measurement.dss_id.measurement.measurement.measurement.dimension.field",
-      "dss.*.server.jvm.memory.pools.*.*                    measurement.dss_id.measurement.measurement.measurement.field.pool.dimension",
-      "dss.*.server.jvm.memory.*.*                          measurement.dss_id.measurement.measurement.field.memory.dimension",
-      "dss.*.server.jvm.memory.total.*                      measurement.dss_id.measurement.measurement.measurement.field.dimension",
-      "dss.*.server.dku.jobs.activities.*                   measurement.dss_id.measurement.measurement.measurement.field.activity_state dimension=count",
-      "dss.*.server.dku.jobs.*.*                            measurement.dss_id.measurement.measurement.field.job_state.dimension",
-      "dss.*.server.dku.objectsCounts.global.*              measurement.dss_id.measurement.measurement.measurement.field.kind dimension=count",
-      "dss.*.server.dku.ml.predictionTrain.*.*              measurement.dss_id.measurement.measurement.measurement.field.kind.dimension",
-      "dss.*.server.dku.notifications.queue.*.size.*        measurement.dss_id.measurement.measurement.measurement.measurement.queue.size.dimension",
-      "dss.*.server.dku.notifications.publish.*.*           measurement.dss_id.measurement.measurement.measurement.field.notification.dimension",
-      "dss.*.server.dku.notifications.publish.*             measurement.dss_id.measurement.measurement.measurement.field.dimension notification=all",
-    ]
-  {% else %}
-  [[inputs.prometheus]]
-    urls = ["http://localhost:10000/public/api/metrics-prometheus"]
-    username = "${DSS_API_KEY}"
   {% endif %}
-  {% endif %}
+  {{ telegraf_conf_dss_monitoring_content }}
 telegraf_conf_outputs_content: |
   [[outputs.prometheus_client]]
 telegraf_conf_additional_content: ""

--- a/roles/install_telegraf/tasks/install_telegraf_deb.yml
+++ b/roles/install_telegraf/tasks/install_telegraf_deb.yml
@@ -19,7 +19,7 @@
   ansible.builtin.apt_repository:
     repo: "deb [signed-by=/etc/apt/keyrings/influxdata-archive.key] https://repos.influxdata.com/{{ ansible_distribution | lower }} stable main"
     state: present
-    filename: telegraf
+    filename: influxdata
   register: repo_telegraf
 
 - name: Update cache

--- a/roles/install_telegraf/tasks/install_telegraf_deb.yml
+++ b/roles/install_telegraf/tasks/install_telegraf_deb.yml
@@ -2,15 +2,15 @@
 - name: Add telegraf repository key
   become: true
   ansible.builtin.apt_key:
-    url: https://repos.influxdata.com/influxdata-archive_compat.key
-    keyring: /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg
+    url: https://repos.influxdata.com/influxdata-archive.key
+    keyring: /etc/apt/trusted.gpg.d/influxdata-archive.gpg
     state: present
 
 - name: Add telegraf repository
   become: true
   # force signing key due to https://github.com/influxdata/telegraf/issues/12542
   ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/{{ ansible_distribution | lower }} stable main"
+    repo: "deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/{{ ansible_distribution | lower }} stable main"
     state: present
     filename: telegraf
   register: repo_telegraf

--- a/roles/install_telegraf/tasks/install_telegraf_deb.yml
+++ b/roles/install_telegraf/tasks/install_telegraf_deb.yml
@@ -1,16 +1,23 @@
 ---
+- name: Ensure apt keyring directory exists
+  become: true
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+
 - name: Add telegraf repository key
   become: true
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: https://repos.influxdata.com/influxdata-archive.key
-    keyring: /etc/apt/trusted.gpg.d/influxdata-archive.gpg
-    state: present
+    dest: /etc/apt/keyrings/influxdata-archive.key
+    mode: "0644"
 
 - name: Add telegraf repository
   become: true
   # force signing key due to https://github.com/influxdata/telegraf/issues/12542
   ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/{{ ansible_distribution | lower }} stable main"
+    repo: "deb [signed-by=/etc/apt/keyrings/influxdata-archive.key] https://repos.influxdata.com/{{ ansible_distribution | lower }} stable main"
     state: present
     filename: telegraf
   register: repo_telegraf
@@ -33,4 +40,5 @@
   ansible.builtin.apt:
     name: "telegraf={{ telegraf_version }}"
     state: present
+    allow_downgrade: true
   when: telegraf_version != None

--- a/roles/install_telegraf/tasks/install_telegraf_rpm.yml
+++ b/roles/install_telegraf/tasks/install_telegraf_rpm.yml
@@ -1,15 +1,17 @@
 ---
-- name: Add the InfluxData GPG key
+- name: Download InfluxData repository key
   become: true
-  ansible.builtin.shell: |
-    curl --silent --location -O \
-    https://repos.influxdata.com/influxdata-archive_compat.key \
-    && echo "393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c  influxdata-archive_compat.key" \
-    | sha256sum --check - && cat influxdata-archive_compat.key \
-    | gpg --dearmor \
-    | tee /etc/pki/rpm-gpg/RPM-GPG-KEY-influxdata > /dev/null
-  args:
-    creates: /etc/pki/rpm-gpg/RPM-GPG-KEY-influxdata
+  ansible.builtin.get_url:
+    url: https://repos.influxdata.com/influxdata-archive.key
+    dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-influxdata
+    mode: "0644"
+    checksum: "sha256:40557e261cdbdccac91a2dde474cbf101ef672661e64b211b711cc0b904d5dac"
+
+- name: Add InfluxData package signing key
+  become: true
+  ansible.builtin.rpm_key:
+    state: present
+    key: /etc/pki/rpm-gpg/RPM-GPG-KEY-influxdata
 
 - name: Add telegraf repository
   become: true


### PR DESCRIPTION
## Changes

- Add missing v1.5.0 changelog
- Update collection version in `galaxy.yml`
- Extract dss monitoring telegraf configuration in a dedicated key
- Improve telegraf installation on deb based distros